### PR TITLE
ツイート一覧機能実装

### DIFF
--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -9,8 +9,8 @@ module Api
 
       def index
         tweets = Tweet.all.order(created_at: 'DESC').includes(%i[user tweet_image]).limit(5).offset(@offset_params)
-        total_tweets_count = Tweet.all.count.to_i
-        render json: { tweets: tweets.as_json(include: :user, methods: :image_url), total_count: total_tweets_count }
+        total_count = Tweet.all.count.to_i
+        render json: { tweets: tweets.as_json(include: :user, methods: :image_url), total_count: }
       end
 
       def create

--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -5,6 +5,13 @@ module Api
     class TweetsController < ApplicationController
       before_action :authenticate_api_v1_user!
       before_action :tweet_image, only: [:create]
+      before_action :offset_param, only: [:index]
+
+      def index
+        tweets = Tweet.all.order(created_at: 'DESC').includes(%i[user tweet_image]).limit(5).offset(@offset_params)
+        total_tweets_count = Tweet.all.count.to_i
+        render json: { tweets: tweets.as_json(include: :user, methods: :image_url), total_count: total_tweets_count }
+      end
 
       def create
         tweet = current_api_v1_user.tweets.build(tweet_params)
@@ -24,6 +31,10 @@ module Api
 
       def tweet_params
         params.permit(:text)
+      end
+
+      def offset_param
+        @offset_params = params[:offset]&.to_i
       end
     end
   end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -7,4 +7,8 @@ class Tweet < ApplicationRecord
   has_one :tweet_image, dependent: :destroy
 
   validates :text, presence: true
+
+  def image_url
+    tweet_image&.image&.attached? ? url_for(tweet_image.image) : nil
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
         registrations: 'api/v1/auth/registrations'
       }
 
-      resources :tweets, only: %i[create]
+      resources :tweets, only: %i[index create]
       resources :tweet_images, path: 'images', only: %i[create]
     end
   end


### PR DESCRIPTION
## 課題のリンク
[ツイート一覧機能](https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%83%84%E3%82%A4%E3%83%BC%E3%83%88%E4%B8%80%E8%A6%A7%E6%A9%9F%E8%83%BD)

## 実装したこと
- 全ユーザーのツイートを取得し、一覧機能を実装しました(/api/v1/tweets)
- limitは固定で5件とし、offsetはパラメータの値としてページネーションを実装しました。